### PR TITLE
Paredit tools

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -15,7 +15,19 @@
     "vscode": {
       "extensions": [
         "rheller.alive"
-      ]
+      ],
+      "tasks": {
+        "version": "2.0.0",
+        "tasks": [
+          {
+            "label": "Run tests",
+            "type": "shell",
+            "command": "qlot exec ros run --eval '(push (truename \".\") asdf:*central-registry*)' --eval '(asdf:test-system \"40ants-lisp-dev-mcp\")' --quit",
+            "group": "test",
+            "presentation": { "reveal": "always", "panel": "shared" }
+          }
+        ]
+      }
     }
   },
   "postCreateCommand": "cd /workspaces/lisp-dev-mcp && qlot install"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,22 @@
+{
+  "name": "40ants-lisp-dev-mcp",
+  "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+  "features": {
+    "ghcr.io/egao1980/features/roswell:1": {
+      "version": "latest",
+      "installLisp": "sbcl-bin",
+      "useLisp": "sbcl-bin",
+      "installTools": true,
+      "toolsToInstall": "qlot",
+      "installUltralisp": true
+    }
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "rheller.alive"
+      ]
+    }
+  },
+  "postCreateCommand": "cd /workspaces/lisp-dev-mcp && qlot install"
+}

--- a/40ants-lisp-dev-mcp-tests.asd
+++ b/40ants-lisp-dev-mcp-tests.asd
@@ -7,7 +7,8 @@
   :source-control (:git "https://github.com/40ants/lisp-dev-mcp")
   :bug-tracker "https://github.com/40ants/lisp-dev-mcp/issues"
   :pathname "t"
-  :depends-on ("40ants-lisp-dev-mcp-tests/core")
+  :depends-on ("40ants-lisp-dev-mcp-tests/core"
+               "40ants-lisp-dev-mcp-tests/paredit")
   :perform (test-op (op c)
                     (unless (symbol-call :rove :run c)
                       (error "Tests failed"))))

--- a/40ants-lisp-dev-mcp.asd
+++ b/40ants-lisp-dev-mcp.asd
@@ -31,3 +31,8 @@
 
 (asdf:register-system-packages "log4cl" '("LOG"))
 (asdf:register-system-packages "bordeaux-threads" '("BORDEAUX-THREADS-2"))
+(asdf:register-system-packages "eclector" '("ECLECTOR.PARSE-RESULT"
+                                            "ECLECTOR.BASE"
+                                            "ECLECTOR.READER"
+                                            "ECLECTOR.READTABLE"))
+(asdf:register-system-packages "yason" '("YASON"))

--- a/40ants-lisp-dev-mcp.asd
+++ b/40ants-lisp-dev-mcp.asd
@@ -21,7 +21,11 @@
                "openrpc-server"
                "jsonrpc/errors"
                "bordeaux-threads"
-               "40ants-lisp-dev-mcp/core")
+               "eclector"
+               "cl-ppcre"
+               "yason"
+               "40ants-lisp-dev-mcp/core"
+               "40ants-lisp-dev-mcp/paredit-tools")
   :in-order-to ((test-op (test-op "40ants-lisp-dev-mcp-tests"))))
 
 

--- a/docs/changelog.lisp
+++ b/docs/changelog.lisp
@@ -8,6 +8,17 @@
 (defchangelog (:ignore-words ("SLY"
                               "ASDF"
                               "REPL"
-                              "HTTP"))
+                              "HTTP"
+                              "CST"
+                              "AST"
+                              "JSON"
+                              "MCP"
+                              "LLM"))
+  (0.2.0 2026-03-06
+         "* Added paredit-style structural editing tools (wrap, unwrap, raise, slurp, barf, kill, transpose, split, join).
+          * Added sexp-replace, sexp-insert-before, sexp-insert-after for code replacement and insertion.
+          * Added sexp-show-structure and sexp-get-enclosing for code inspection.
+          * Added sexp-to-json-ast for CST-based JSON AST output.
+          * Added Eclector-based CST parser with source position tracking.")
   (0.1.0 2026-01-25
          "* Initial version."))

--- a/docs/index.lisp
+++ b/docs/index.lisp
@@ -55,7 +55,10 @@
                                    "URL"
                                    "URI"
                                    "RPC"
-                                   "GIT"))
+                                   "GIT"
+                                   "CST"
+                                   "AST"
+                                   "S-expression"))
   (40ants-lisp-dev-mcp system)
   "
 [![](https://github-actions.40ants.com/40ants/lisp-dev-mcp/matrix.svg?only=ci.run-tests)](https://github.com/40ants/lisp-dev-mcp/actions)

--- a/src/core.lisp
+++ b/src/core.lisp
@@ -19,7 +19,8 @@
                 #:define-tool)
   (:import-from #:bordeaux-threads-2
                 #:make-thread)
-  (:export #:start-server))
+  (:export #:start-server
+           #:dev-tools))
 (in-package #:40ants-lisp-dev-mcp/core)
 
 

--- a/src/cst.lisp
+++ b/src/cst.lisp
@@ -1,0 +1,118 @@
+(uiop:define-package #:40ants-lisp-dev-mcp/cst
+  (:use #:cl)
+  (:export #:cst-node
+           #:make-cst-node
+           #:cst-node-kind
+           #:cst-node-value
+           #:cst-node-children
+           #:cst-node-start
+           #:cst-node-end
+           #:cst-node-start-line
+           #:cst-node-end-line
+           #:parse-top-level-forms))
+(in-package #:40ants-lisp-dev-mcp/cst)
+
+
+(defstruct cst-node
+  "A node in a concrete syntax tree with source positions."
+  (kind :expr :type keyword)
+  (value nil)
+  (children nil :type list)
+  (start 0 :type fixnum)
+  (end 0 :type fixnum)
+  (start-line 1 :type fixnum)
+  (end-line 1 :type fixnum))
+
+
+;;; Eclector parse-result client that tracks character offsets
+
+(defclass cst-client (eclector.parse-result:parse-result-client)
+  ((source-text :initarg :source-text :reader client-source-text)))
+
+(defmethod eclector.base:source-position ((client cst-client) stream)
+  (file-position stream))
+
+(defmethod eclector.base:make-source-range ((client cst-client) start end)
+  (cons start end))
+
+(defmethod eclector.reader:interpret-symbol
+    ((client cst-client) input-stream
+     package-indicator symbol-name internp)
+  "Intern symbols leniently: create missing packages on the fly so that
+   parsing arbitrary Lisp source never fails due to unknown packages."
+  (let ((package
+          (cond
+            ((null package-indicator)
+             (return-from eclector.reader:interpret-symbol
+               (make-symbol symbol-name)))
+            ((eq package-indicator :keyword) (find-package :keyword))
+            ((eq package-indicator :current) *package*)
+            (t (or (find-package package-indicator)
+                   (make-package package-indicator :use '()))))))
+    (if internp
+        (intern symbol-name package)
+        (let ((sym (find-symbol symbol-name package)))
+          (or sym (intern symbol-name package))))))
+
+(defmethod eclector.reader:evaluate-expression ((client cst-client) expression)
+  "Suppress read-time evaluation for safety."
+  expression)
+
+(defun count-newlines-before (text position)
+  "Count line number (1-based) at POSITION in TEXT."
+  (1+ (count #\Newline text :end (min position (length text)))))
+
+(defmethod eclector.parse-result:make-expression-result
+    ((client cst-client) result children source)
+  (let ((start (car source))
+        (end (cdr source))
+        (text (client-source-text client)))
+    (make-cst-node :kind :expr
+                   :value result
+                   :children (remove nil children)
+                   :start start
+                   :end end
+                   :start-line (count-newlines-before text start)
+                   :end-line (count-newlines-before text end))))
+
+(defmethod eclector.parse-result:make-skipped-input-result
+    ((client cst-client) stream reason children source)
+  (declare (ignore stream children))
+  (when (member reason '(:line-comment :block-comment
+                         (:sharpsign-plus :if) (:sharpsign-plus :else)
+                         (:sharpsign-minus :if) (:sharpsign-minus :else))
+                :test #'equal)
+    (let ((start (car source))
+          (end (cdr source))
+          (text (client-source-text client)))
+      (make-cst-node :kind :skipped
+                     :value reason
+                     :start start
+                     :end end
+                     :start-line (count-newlines-before text start)
+                     :end-line (count-newlines-before text end)))))
+
+
+(defun parse-top-level-forms (text)
+  "Parse TEXT into a list of CST-NODE objects representing top-level forms.
+   Returns all forms including comments."
+  (let* ((client (make-instance 'cst-client :source-text text))
+         (results '())
+         (*package* (find-package :cl-user))
+         (*read-eval* nil))
+    (with-input-from-string (stream text)
+      (loop
+        (multiple-value-bind (result orphans)
+            (eclector.parse-result:read client stream nil stream)
+          (when (eq result stream)
+            ;; Collect any trailing orphans (comments after last form)
+            (when orphans
+              (dolist (o orphans)
+                (when o (push o results))))
+            (return))
+          ;; Collect orphans that precede this form (e.g. comments)
+          (when orphans
+            (dolist (o orphans)
+              (when o (push o results))))
+          (push result results))))
+    (nreverse results)))

--- a/src/cst.lisp
+++ b/src/cst.lisp
@@ -1,5 +1,11 @@
 (uiop:define-package #:40ants-lisp-dev-mcp/cst
   (:use #:cl)
+  (:import-from #:eclector.parse-result
+                #:parse-result-client
+                #:make-expression-result
+                #:make-skipped-input-result)
+  (:import-from #:eclector.base)
+  (:import-from #:eclector.reader)
   (:export #:cst-node
            #:make-cst-node
            #:cst-node-kind

--- a/src/paredit-tools.lisp
+++ b/src/paredit-tools.lisp
@@ -1,0 +1,476 @@
+(uiop:define-package #:40ants-lisp-dev-mcp/paredit-tools
+  (:use #:cl)
+  (:import-from #:40ants-mcp/tools
+                #:define-tool)
+  (:import-from #:40ants-mcp/content/text
+                #:text-content)
+  (:import-from #:40ants-mcp/server/errors
+                #:tool-error)
+  (:import-from #:40ants-lisp-dev-mcp/core
+                #:dev-tools)
+  (:import-from #:40ants-lisp-dev-mcp/cst
+                #:parse-top-level-forms
+                #:make-cst-node)
+  (:import-from #:40ants-lisp-dev-mcp/paredit
+                #:resolve-target
+                #:transform-wrap
+                #:transform-unwrap
+                #:transform-raise
+                #:transform-slurp-forward
+                #:transform-slurp-backward
+                #:transform-barf-forward
+                #:transform-barf-backward
+                #:transform-kill
+                #:transform-transpose
+                #:transform-split
+                #:transform-join
+                #:transform-replace
+                #:transform-insert-before
+                #:transform-insert-after
+                #:show-structure
+                #:get-enclosing
+                #:cst-to-json-ast
+                #:paredit-error
+                #:node-source
+                #:node-list-p
+                #:find-parent))
+(in-package #:40ants-lisp-dev-mcp/paredit-tools)
+
+
+;;; Shared helpers for all paredit tools
+
+(defun parse-path-string (path-str)
+  "Parse a comma-separated path string like \"2,0,1\" into a list of integers."
+  (when (and path-str (plusp (length path-str)))
+    (mapcar #'parse-integer
+            (uiop:split-string path-str :separator ","))))
+
+(defun apply-paredit-tool (code form-type form-name target path line
+                           transform-fn &rest transform-args)
+  "Parse CODE, resolve target, apply TRANSFORM-FN, return new text.
+   Handles empty code for insert operations."
+  (handler-case
+      (if (and (or (null code) (string= code ""))
+               (null target) (null path))
+          ;; Empty input: create a synthetic empty root for insert operations
+          (let* ((root (make-cst-node :kind :expr :value nil
+                                      :start 0 :end 0))
+                 (new-text (apply transform-fn "" root root transform-args)))
+            new-text)
+          (let* ((text (or code ""))
+                 (nodes (parse-top-level-forms text)))
+            (when (null nodes)
+              (error 'paredit-error
+                     :format-control "No forms found in code"
+                     :format-arguments nil))
+            (multiple-value-bind (target-node root-node)
+                (resolve-target nodes text
+                                :form-type form-type
+                                :form-name form-name
+                                :target target
+                                :path (parse-path-string path)
+                                :line line)
+              (apply transform-fn text root-node target-node transform-args))))
+    (paredit-error (e)
+      (error 'tool-error
+             :content (list (make-instance 'text-content
+                                           :text (format nil "~A" e)))))))
+
+
+;;; Tool definitions — all registered under the dev-tools API
+
+(define-tool (dev-tools sexp-wrap) (code &key form-type form-name target path line
+                                         (count 1) wrapper head)
+  (:summary "Wrap one or more S-expressions in new delimiters.
+
+             Wraps the targeted expression (and optionally COUNT-1 following
+             siblings) in parentheses. Use WRAPPER to choose delimiter type
+             (round, square, curly). Use HEAD to prepend a symbol inside.")
+  (:param code string "Lisp source code to transform.")
+  (:param form-type string "Type of top-level form to scope to (e.g. \"defun\").")
+  (:param form-name string "Name of top-level form (e.g. \"foo\"). Supports [N] index.")
+  (:param target string "Source text of the target S-expression.")
+  (:param path string "Child index path, comma-separated (e.g. \"2,0,1\").")
+  (:param line integer "Line number hint for disambiguation.")
+  (:param count integer "Number of siblings to wrap (default 1).")
+  (:param wrapper string "Delimiter type: round, square, curly (default round).")
+  (:param head string "Symbol to prepend inside the wrapper (e.g. \"progn\").")
+  (:result (soft-list-of text-content))
+  (list (make-instance 'text-content
+                       :text (apply-paredit-tool code form-type form-name
+                                                 target path line
+                                                 #'transform-wrap
+                                                 :count count
+                                                 :wrapper wrapper
+                                                 :head head))))
+
+
+(define-tool (dev-tools sexp-unwrap) (code &key form-type form-name target path line
+                                           (keep "all"))
+  (:summary "Remove list delimiters and splice children into parent.
+
+             Use KEEP=\"body\" to also drop the operator (first child).")
+  (:param code string "Lisp source code to transform.")
+  (:param form-type string "Type of top-level form to scope to.")
+  (:param form-name string "Name of top-level form.")
+  (:param target string "Source text of the target list.")
+  (:param path string "Child index path, comma-separated.")
+  (:param line integer "Line number hint.")
+  (:param keep string "\"all\" keeps all children, \"body\" drops operator.")
+  (:result (soft-list-of text-content))
+  (list (make-instance 'text-content
+                       :text (apply-paredit-tool code form-type form-name
+                                                 target path line
+                                                 #'transform-unwrap
+                                                 :keep keep))))
+
+
+(define-tool (dev-tools sexp-raise) (code &key form-type form-name target path line)
+  (:summary "Replace parent with the targeted child expression.
+
+             The targeted expression replaces its enclosing list.")
+  (:param code string "Lisp source code to transform.")
+  (:param form-type string "Type of top-level form to scope to.")
+  (:param form-name string "Name of top-level form.")
+  (:param target string "Source text of the expression to raise.")
+  (:param path string "Child index path, comma-separated.")
+  (:param line integer "Line number hint.")
+  (:result (soft-list-of text-content))
+  (list (make-instance 'text-content
+                       :text (apply-paredit-tool code form-type form-name
+                                                 target path line
+                                                 #'transform-raise))))
+
+
+(define-tool (dev-tools sexp-slurp-forward) (code &key form-type form-name
+                                                   target path line (count 1))
+  (:summary "Pull following sibling(s) into the targeted list.
+
+             The closing delimiter moves right to absorb COUNT siblings.")
+  (:param code string "Lisp source code to transform.")
+  (:param form-type string "Type of top-level form to scope to.")
+  (:param form-name string "Name of top-level form.")
+  (:param target string "Source text of the target list.")
+  (:param path string "Child index path, comma-separated.")
+  (:param line integer "Line number hint.")
+  (:param count integer "Number of siblings to slurp (default 1).")
+  (:result (soft-list-of text-content))
+  (list (make-instance 'text-content
+                       :text (apply-paredit-tool code form-type form-name
+                                                 target path line
+                                                 #'transform-slurp-forward
+                                                 :count count))))
+
+
+(define-tool (dev-tools sexp-slurp-backward) (code &key form-type form-name
+                                                    target path line (count 1))
+  (:summary "Pull preceding sibling(s) into the targeted list.
+
+             The opening delimiter moves left to absorb COUNT siblings.")
+  (:param code string "Lisp source code to transform.")
+  (:param form-type string "Type of top-level form to scope to.")
+  (:param form-name string "Name of top-level form.")
+  (:param target string "Source text of the target list.")
+  (:param path string "Child index path, comma-separated.")
+  (:param line integer "Line number hint.")
+  (:param count integer "Number of siblings to slurp (default 1).")
+  (:result (soft-list-of text-content))
+  (list (make-instance 'text-content
+                       :text (apply-paredit-tool code form-type form-name
+                                                 target path line
+                                                 #'transform-slurp-backward
+                                                 :count count))))
+
+
+(define-tool (dev-tools sexp-barf-forward) (code &key form-type form-name
+                                                  target path line (count 1))
+  (:summary "Push last child(ren) out of the targeted list as following siblings.
+
+             The closing delimiter moves left, ejecting COUNT trailing children.")
+  (:param code string "Lisp source code to transform.")
+  (:param form-type string "Type of top-level form to scope to.")
+  (:param form-name string "Name of top-level form.")
+  (:param target string "Source text of the target list.")
+  (:param path string "Child index path, comma-separated.")
+  (:param line integer "Line number hint.")
+  (:param count integer "Number of children to barf out (default 1).")
+  (:result (soft-list-of text-content))
+  (list (make-instance 'text-content
+                       :text (apply-paredit-tool code form-type form-name
+                                                 target path line
+                                                 #'transform-barf-forward
+                                                 :count count))))
+
+
+(define-tool (dev-tools sexp-barf-backward) (code &key form-type form-name
+                                                   target path line (count 1))
+  (:summary "Push first child(ren) out of the targeted list as preceding siblings.
+
+             The opening delimiter moves right, ejecting COUNT leading children.")
+  (:param code string "Lisp source code to transform.")
+  (:param form-type string "Type of top-level form to scope to.")
+  (:param form-name string "Name of top-level form.")
+  (:param target string "Source text of the target list.")
+  (:param path string "Child index path, comma-separated.")
+  (:param line integer "Line number hint.")
+  (:param count integer "Number of children to barf out (default 1).")
+  (:result (soft-list-of text-content))
+  (list (make-instance 'text-content
+                       :text (apply-paredit-tool code form-type form-name
+                                                 target path line
+                                                 #'transform-barf-backward
+                                                 :count count))))
+
+
+(define-tool (dev-tools sexp-kill) (code &key form-type form-name target path line
+                                         (count 1))
+  (:summary "Delete one or more complete S-expressions.
+
+             Removes the targeted expression and cleans up surrounding whitespace.
+             Use COUNT to kill multiple consecutive siblings.")
+  (:param code string "Lisp source code to transform.")
+  (:param form-type string "Type of top-level form to scope to.")
+  (:param form-name string "Name of top-level form.")
+  (:param target string "Source text of the expression to kill.")
+  (:param path string "Child index path, comma-separated.")
+  (:param line integer "Line number hint.")
+  (:param count integer "Number of siblings to kill (default 1).")
+  (:result (soft-list-of text-content))
+  (list (make-instance 'text-content
+                       :text (apply-paredit-tool code form-type form-name
+                                                 target path line
+                                                 #'transform-kill
+                                                 :count count))))
+
+
+(define-tool (dev-tools sexp-transpose) (code &key form-type form-name
+                                               target path line)
+  (:summary "Swap the targeted expression with its next sibling.
+
+             The two adjacent siblings exchange positions.")
+  (:param code string "Lisp source code to transform.")
+  (:param form-type string "Type of top-level form to scope to.")
+  (:param form-name string "Name of top-level form.")
+  (:param target string "Source text of the expression to transpose.")
+  (:param path string "Child index path, comma-separated.")
+  (:param line integer "Line number hint.")
+  (:result (soft-list-of text-content))
+  (list (make-instance 'text-content
+                       :text (apply-paredit-tool code form-type form-name
+                                                 target path line
+                                                 #'transform-transpose))))
+
+
+(define-tool (dev-tools sexp-split) (code &key form-type form-name target path line
+                                          clone-head)
+  (:summary "Split the parent list at the targeted expression.
+
+             The parent list is split into two lists. TARGET becomes the first
+             element of the second list. Use CLONE-HEAD to copy the operator
+             to both halves.")
+  (:param code string "Lisp source code to transform.")
+  (:param form-type string "Type of top-level form to scope to.")
+  (:param form-name string "Name of top-level form.")
+  (:param target string "Source text of the split point expression.")
+  (:param path string "Child index path, comma-separated.")
+  (:param line integer "Line number hint.")
+  (:param clone-head boolean "If true, copy operator to both halves.")
+  (:result (soft-list-of text-content))
+  (list (make-instance 'text-content
+                       :text (apply-paredit-tool code form-type form-name
+                                                 target path line
+                                                 #'transform-split
+                                                 :clone-head clone-head))))
+
+
+(define-tool (dev-tools sexp-join) (code &key form-type form-name target path line
+                                         drop-head)
+  (:summary "Join the targeted list with its next sibling list.
+
+             Merges two adjacent lists into one. Use DROP-HEAD to discard
+             the second list's operator.")
+  (:param code string "Lisp source code to transform.")
+  (:param form-type string "Type of top-level form to scope to.")
+  (:param form-name string "Name of top-level form.")
+  (:param target string "Source text of the first list to join.")
+  (:param path string "Child index path, comma-separated.")
+  (:param line integer "Line number hint.")
+  (:param drop-head boolean "If true, discard the second list's operator.")
+  (:result (soft-list-of text-content))
+  (list (make-instance 'text-content
+                       :text (apply-paredit-tool code form-type form-name
+                                                 target path line
+                                                 #'transform-join
+                                                 :drop-head drop-head))))
+
+
+(define-tool (dev-tools sexp-replace) (code new-code &key form-type form-name
+                                                      target path line)
+  (:summary "Replace the targeted S-expression with new code.
+
+             The matched node is replaced with the provided NEW-CODE string.")
+  (:param code string "Lisp source code to transform.")
+  (:param new-code string "Replacement source code.")
+  (:param form-type string "Type of top-level form to scope to.")
+  (:param form-name string "Name of top-level form.")
+  (:param target string "Source text of the expression to replace.")
+  (:param path string "Child index path, comma-separated.")
+  (:param line integer "Line number hint.")
+  (:result (soft-list-of text-content))
+  (list (make-instance 'text-content
+                       :text (apply-paredit-tool code form-type form-name
+                                                 target path line
+                                                 #'transform-replace
+                                                 :new-code new-code))))
+
+
+(define-tool (dev-tools sexp-insert-before) (code new-code &key form-type form-name
+                                                             target path line)
+  (:summary "Insert new code before the targeted expression.
+
+             When no target is specified, prepends to the beginning of the code.
+             Works with empty code input to build files from scratch.")
+  (:param code string "Lisp source code to transform (can be empty).")
+  (:param new-code string "New source code to insert.")
+  (:param form-type string "Type of top-level form to scope to.")
+  (:param form-name string "Name of top-level form.")
+  (:param target string "Source text of the reference expression.")
+  (:param path string "Child index path, comma-separated.")
+  (:param line integer "Line number hint.")
+  (:result (soft-list-of text-content))
+  (list (make-instance 'text-content
+                       :text (apply-paredit-tool code form-type form-name
+                                                 target path line
+                                                 #'transform-insert-before
+                                                 :new-code new-code))))
+
+
+(define-tool (dev-tools sexp-insert-after) (code new-code &key form-type form-name
+                                                            target path line)
+  (:summary "Insert new code after the targeted expression.
+
+             When no target is specified, appends to the end of the code.
+             Works with empty code input to build files from scratch.")
+  (:param code string "Lisp source code to transform (can be empty).")
+  (:param new-code string "New source code to insert.")
+  (:param form-type string "Type of top-level form to scope to.")
+  (:param form-name string "Name of top-level form.")
+  (:param target string "Source text of the reference expression.")
+  (:param path string "Child index path, comma-separated.")
+  (:param line integer "Line number hint.")
+  (:result (soft-list-of text-content))
+  (list (make-instance 'text-content
+                       :text (apply-paredit-tool code form-type form-name
+                                                 target path line
+                                                 #'transform-insert-after
+                                                 :new-code new-code))))
+
+
+(define-tool (dev-tools sexp-show-structure) (code &key form-type form-name
+                                                    target path line
+                                                    (depth 4) (max-text 60))
+  (:summary "Show the structure tree of the code or targeted expression.
+
+             Returns an indented tree of paths, node kinds, line numbers,
+             and text snippets. Read-only — does not modify the code.")
+  (:param code string "Lisp source code to inspect.")
+  (:param form-type string "Type of top-level form to scope to.")
+  (:param form-name string "Name of top-level form.")
+  (:param target string "Source text of expression to inspect.")
+  (:param path string "Child index path, comma-separated.")
+  (:param line integer "Line number hint.")
+  (:param depth integer "Maximum tree depth to display (default 4).")
+  (:param max-text integer "Maximum text length per node (default 60).")
+  (:result (soft-list-of text-content))
+  (handler-case
+      (let* ((text (or code ""))
+             (nodes (parse-top-level-forms text)))
+        (multiple-value-bind (target-node root-node)
+            (resolve-target nodes text
+                            :form-type form-type
+                            :form-name form-name
+                            :target target
+                            :path (parse-path-string path)
+                            :line line)
+          (declare (ignore root-node))
+          (list (make-instance 'text-content
+                               :text (show-structure target-node text
+                                                     :depth depth
+                                                     :max-text max-text)))))
+    (paredit-error (e)
+      (error 'tool-error
+             :content (list (make-instance 'text-content
+                                           :text (format nil "~A" e)))))))
+
+
+(define-tool (dev-tools sexp-to-json-ast) (code &key form-type form-name
+                                                 (depth 6) (max-text 120))
+  (:summary "Parse Lisp code and return a JSON AST (Abstract Syntax Tree).
+
+             Returns a JSON array of top-level form objects. Each object has:
+             type (list/symbol/string/number/atom), path (index array),
+             line, start, end, text, and for lists: head (operator name)
+             and children (nested array of the same structure).
+
+             This is the preferred way for LLMs to understand code structure
+             before applying structural edits. The path arrays in the output
+             can be used directly as the 'path' parameter in other sexp- tools.")
+  (:param code string "Lisp source code to parse.")
+  (:param form-type string "Type of top-level form to scope to (e.g. \"defun\").")
+  (:param form-name string "Name of top-level form (e.g. \"foo\").")
+  (:param depth integer "Maximum tree depth (default 6).")
+  (:param max-text integer "Maximum text length per node (default 120).")
+  (:result (soft-list-of text-content))
+  (handler-case
+      (let* ((text (or code ""))
+             (nodes (parse-top-level-forms text))
+             (scoped-nodes
+               (if (and form-type form-name)
+                   (multiple-value-bind (target-node root-node)
+                       (resolve-target nodes text
+                                       :form-type form-type
+                                       :form-name form-name)
+                     (declare (ignore root-node))
+                     (list target-node))
+                   nodes)))
+        (list (make-instance 'text-content
+                             :text (cst-to-json-ast scoped-nodes text
+                                                    :depth depth
+                                                    :max-text max-text))))
+    (paredit-error (e)
+      (error 'tool-error
+             :content (list (make-instance 'text-content
+                                           :text (format nil "~A" e)))))))
+
+
+(define-tool (dev-tools sexp-get-enclosing) (code &key form-type form-name
+                                                   target path line (levels 1))
+  (:summary "Return info about the enclosing form of the targeted expression.
+
+             Shows the head symbol, kind, child index, sibling count, line
+             number, and text of the enclosing form. Read-only.")
+  (:param code string "Lisp source code to inspect.")
+  (:param form-type string "Type of top-level form to scope to.")
+  (:param form-name string "Name of top-level form.")
+  (:param target string "Source text of expression to find enclosing for.")
+  (:param path string "Child index path, comma-separated.")
+  (:param line integer "Line number hint.")
+  (:param levels integer "Number of enclosing levels to traverse (default 1).")
+  (:result (soft-list-of text-content))
+  (handler-case
+      (let* ((text (or code ""))
+             (nodes (parse-top-level-forms text)))
+        (multiple-value-bind (target-node root-node)
+            (resolve-target nodes text
+                            :form-type form-type
+                            :form-name form-name
+                            :target target
+                            :path (parse-path-string path)
+                            :line line)
+          (list (make-instance 'text-content
+                               :text (get-enclosing root-node target-node text
+                                                    :levels levels)))))
+    (paredit-error (e)
+      (error 'tool-error
+             :content (list (make-instance 'text-content
+                                           :text (format nil "~A" e)))))))

--- a/src/paredit-tools.lisp
+++ b/src/paredit-tools.lisp
@@ -37,7 +37,7 @@
 (in-package #:40ants-lisp-dev-mcp/paredit-tools)
 
 
-;;; Shared helpers for all paredit tools
+;;; Helpers for all paredit tools
 
 (defun parse-path-string (path-str)
   "Parse a comma-separated path string like \"2,0,1\" into a list of integers."

--- a/src/paredit.lisp
+++ b/src/paredit.lisp
@@ -1,0 +1,695 @@
+(uiop:define-package #:40ants-lisp-dev-mcp/paredit
+  (:use #:cl)
+  (:import-from #:cl-ppcre
+                #:scan-to-strings
+                #:regex-replace-all)
+  (:import-from #:40ants-lisp-dev-mcp/cst
+                #:cst-node
+                #:make-cst-node
+                #:cst-node-kind
+                #:cst-node-value
+                #:cst-node-children
+                #:cst-node-start
+                #:cst-node-end
+                #:cst-node-start-line
+                #:cst-node-end-line
+                #:parse-top-level-forms)
+  (:export ;; Target resolution
+           #:resolve-target
+           ;; Transform functions
+           #:transform-wrap
+           #:transform-unwrap
+           #:transform-raise
+           #:transform-slurp-forward
+           #:transform-slurp-backward
+           #:transform-barf-forward
+           #:transform-barf-backward
+           #:transform-kill
+           #:transform-transpose
+           #:transform-split
+           #:transform-join
+           #:transform-replace
+           #:transform-insert-before
+           #:transform-insert-after
+           ;; Read-only operations
+           #:show-structure
+           #:get-enclosing
+           #:cst-to-json-ast
+           ;; Helpers used by tools
+           #:paredit-error
+           #:node-source
+           #:node-list-p
+           #:find-parent))
+(in-package #:40ants-lisp-dev-mcp/paredit)
+
+
+;;;; Error handling
+
+(define-condition paredit-error (simple-error)
+  ()
+  (:documentation "Signaled when a structural edit cannot be performed."))
+
+(defun op-error (fmt &rest args)
+  "Signal a PAREDIT-ERROR with a formatted message."
+  (error 'paredit-error
+         :format-control fmt
+         :format-arguments args))
+
+
+;;;; Node predicates and accessors
+
+(defun node-list-p (node)
+  "True if NODE is an :expr CST node whose value is a cons (i.e. a list form)."
+  (and (typep node 'cst-node)
+       (eq (cst-node-kind node) :expr)
+       (consp (cst-node-value node))))
+
+(defun node-atom-p (node)
+  (and (typep node 'cst-node)
+       (eq (cst-node-kind node) :expr)
+       (atom (cst-node-value node))))
+
+(defun node-source (text node)
+  "Extract the source text for NODE from TEXT."
+  (subseq text (cst-node-start node) (cst-node-end node)))
+
+(defun expr-children (node)
+  "Return only :expr CST-NODE children of NODE."
+  (remove-if-not (lambda (c)
+                   (and (typep c 'cst-node)
+                        (eq (cst-node-kind c) :expr)))
+                 (cst-node-children node)))
+
+(defun node-head-name (node)
+  "If NODE is a list whose CAR is a symbol, return its lowercase name."
+  (when (node-list-p node)
+    (let ((children (expr-children node)))
+      (when (and children
+                 (node-atom-p (first children))
+                 (symbolp (cst-node-value (first children))))
+        (string-downcase (symbol-name (cst-node-value (first children))))))))
+
+(defun normalize-string (thing)
+  (string-downcase (princ-to-string thing)))
+
+
+;;;; Top-level form matching
+
+(defun defmethod-candidates (form)
+  "Generate candidate name strings for a defmethod form."
+  (destructuring-bind (_head name &rest rest) form
+    (declare (ignore _head))
+    (let ((qualifiers '())
+          (lambda-list nil))
+      (dolist (part rest)
+        (when (listp part)
+          (setf lambda-list part)
+          (return))
+        (push part qualifiers))
+      (let ((name-str (normalize-string name))
+            (lambda-str (when lambda-list
+                          (normalize-string (format nil "~S" lambda-list))))
+            (qual-str (when qualifiers
+                        (normalize-string
+                         (format nil "~{~S~^ ~}" (nreverse qualifiers))))))
+        (remove nil (list name-str
+                         (when qual-str
+                           (format nil "~A ~A" name-str qual-str))
+                         (when lambda-str
+                           (format nil "~A ~A" name-str lambda-str))
+                         (when (and qual-str lambda-str)
+                           (format nil "~A ~A ~A"
+                                   name-str qual-str lambda-str))))))))
+
+(defun definition-candidates (form form-type)
+  "Generate candidate name strings for a definition form."
+  (let ((name (second form)))
+    (cond
+      ((string= form-type "defmethod") (defmethod-candidates form))
+      ((symbolp name) (list (normalize-string name)))
+      (t (list (normalize-string name))))))
+
+(defun find-top-level-form (nodes form-type form-name)
+  "Find a top-level CST node matching FORM-TYPE and FORM-NAME.
+   FORM-NAME can include [N] index suffix for disambiguation."
+  (multiple-value-bind (base-name index)
+      (let ((match (nth-value 1 (scan-to-strings
+                                 "^(.+?)\\[(\\d+)\\]$" form-name))))
+        (if match
+            (values (aref match 0) (parse-integer (aref match 1)))
+            (values form-name nil)))
+    (let ((target (string-downcase base-name))
+          (ft (string-downcase form-type))
+          (matches nil))
+      (loop for node in nodes
+            when (and (typep node 'cst-node)
+                      (eq (cst-node-kind node) :expr)
+                      (consp (cst-node-value node)))
+              do (let ((val (cst-node-value node)))
+                   (when (and (string= (string-downcase
+                                        (symbol-name (car val)))
+                                       ft)
+                              (some (lambda (c) (string= c target))
+                                    (definition-candidates val ft)))
+                     (push node matches))))
+      (setf matches (nreverse matches))
+      (cond
+        ((null matches) nil)
+        ((and index (< index (length matches)))
+         (nth index matches))
+        (index
+         (op-error "Index [~D] out of range, ~D match~:P found"
+                   index (length matches)))
+        ((= (length matches) 1)
+         (first matches))
+        (t (op-error "~D matches for ~A ~A. Use [N] index to disambiguate."
+                     (length matches) form-type form-name))))))
+
+
+;;;; Target resolution
+
+(defun whitespace-normalize (text)
+  (string-trim '(#\Space #\Tab #\Newline #\Return)
+               (regex-replace-all "\\s+" text " ")))
+
+(defun collect-all-nodes (root)
+  "Depth-first collection of all :expr CST nodes under ROOT."
+  (let ((result '()))
+    (labels ((walk (node)
+               (when (and (typep node 'cst-node)
+                          (eq (cst-node-kind node) :expr))
+                 (push node result)
+                 (dolist (child (cst-node-children node))
+                   (walk child)))))
+      (walk root))
+    (nreverse result)))
+
+(defun resolve-by-path (root path)
+  "Navigate into ROOT using PATH (list of child indices)."
+  (let ((current root))
+    (dolist (idx path current)
+      (unless (node-list-p current)
+        (op-error "Cannot navigate into atom at path index ~D" idx))
+      (let ((children (expr-children current)))
+        (when (>= idx (length children))
+          (op-error "Path index ~D out of range (~D children)"
+                    idx (length children)))
+        (setf current (nth idx children))))))
+
+(defun resolve-by-text (root target-text source-text &key line)
+  "Find a descendant of ROOT whose source matches TARGET-TEXT."
+  (let ((normalized (whitespace-normalize target-text))
+        (nodes (collect-all-nodes root))
+        (exact '())
+        (prefix '()))
+    (dolist (node nodes)
+      (let* ((src (node-source source-text node))
+             (nsrc (whitespace-normalize src)))
+        (cond
+          ((string= nsrc normalized) (push node exact))
+          ((and (> (length nsrc) (length normalized))
+                (string= nsrc normalized :end1 (length normalized)))
+           (push node prefix)))))
+    (let ((matches (or (nreverse exact) (nreverse prefix))))
+      (cond
+        ((null matches)
+         (op-error "No matching node for target: ~A" target-text))
+        ((= (length matches) 1)
+         (first matches))
+        (line
+         (first (sort matches #'<
+                      :key (lambda (n)
+                             (abs (- (cst-node-start-line n) line))))))
+        (t
+         (op-error "~D matches for target. Add line hint or use path."
+                   (length matches)))))))
+
+(defun resolve-target (nodes text &key form-type form-name target path line)
+  "Unified target resolution. Returns (values target-node root-node).
+   ROOT-NODE is either the matched top-level form or a synthetic root
+   wrapping all nodes."
+  (let ((root (if (and form-type form-name)
+                  (or (find-top-level-form nodes form-type form-name)
+                      (op-error "Top-level form ~A ~A not found"
+                                form-type form-name))
+                  (if (= 1 (length nodes))
+                      (first nodes)
+                      (make-cst-node :kind :expr
+                                     :value nil
+                                     :children nodes
+                                     :start 0
+                                     :end (length text))))))
+    (cond
+      (path (values (resolve-by-path root path) root))
+      (target (values (resolve-by-text root target text :line line) root))
+      (t (values root root)))))
+
+
+;;;; Tree navigation
+
+(defun find-parent (root target)
+  "Find the parent of TARGET within ROOT. NIL if TARGET is ROOT."
+  (labels ((search-in (node)
+             (dolist (child (cst-node-children node))
+               (when (typep child 'cst-node)
+                 (when (eq child target)
+                   (return-from find-parent node))
+                 (search-in child)))))
+    (search-in root)
+    nil))
+
+(defun find-siblings (parent target)
+  "Returns (values before-list target-node after-list)
+   among PARENT's :expr children."
+  (let ((children (expr-children parent))
+        (before '())
+        (found nil)
+        (after '()))
+    (dolist (child children)
+      (cond (found (push child after))
+            ((eq child target) (setf found child))
+            (t (push child before))))
+    (values (nreverse before) found (nreverse after))))
+
+
+;;;; Transform functions
+;;;; All transforms are pure: (text root target &key ...) -> new-text
+
+(defun transform-wrap (text root target &key (count 1) wrapper head)
+  "Wrap TARGET (and optionally COUNT-1 following siblings) in new delimiters."
+  (let ((parent (find-parent root target)))
+    (unless parent (op-error "Cannot wrap: target has no parent"))
+    (multiple-value-bind (_bef _found aft) (find-siblings parent target)
+      (declare (ignore _bef _found))
+      (let* ((wrap-nodes (cons target
+                               (subseq aft 0 (min (1- count) (length aft)))))
+             (rstart (cst-node-start (first wrap-nodes)))
+             (rend (cst-node-end (car (last wrap-nodes))))
+             (region (subseq text rstart rend))
+             (open (cond ((or (null wrapper) (string= wrapper "round")) "(")
+                         ((string= wrapper "square") "[")
+                         ((string= wrapper "curly") "{")
+                         (t "(")))
+             (close (cond ((or (null wrapper) (string= wrapper "round")) ")")
+                          ((string= wrapper "square") "]")
+                          ((string= wrapper "curly") "}")
+                          (t ")")))
+             (wrapped (if head
+                          (format nil "~A~A ~A~A" open head region close)
+                          (format nil "~A~A~A" open region close))))
+        (concatenate 'string
+                     (subseq text 0 rstart) wrapped (subseq text rend))))))
+
+(defun transform-unwrap (text root target &key (keep "all"))
+  "Remove list delimiters from TARGET, splicing children into parent.
+   KEEP: \"all\" keeps all children, \"body\" drops the operator."
+  (declare (ignore root))
+  (unless (node-list-p target)
+    (op-error "Cannot unwrap: target is not a list"))
+  (let* ((children (expr-children target))
+         (keep-children (if (string= keep "body")
+                            (rest children)
+                            children)))
+    (when (null keep-children)
+      (op-error "Cannot unwrap: no children to keep"))
+    (let ((replacement
+            (format nil "~{~A~^ ~}"
+                    (mapcar (lambda (n) (node-source text n))
+                            keep-children))))
+      (concatenate 'string
+                   (subseq text 0 (cst-node-start target))
+                   replacement
+                   (subseq text (cst-node-end target))))))
+
+(defun transform-raise (text root target)
+  "Replace parent with TARGET, effectively raising it one level."
+  (let ((parent (find-parent root target)))
+    (unless parent (op-error "Cannot raise: target has no parent"))
+    (concatenate 'string
+                 (subseq text 0 (cst-node-start parent))
+                 (node-source text target)
+                 (subseq text (cst-node-end parent)))))
+
+(defun transform-slurp-forward (text root target &key (count 1))
+  "Pull COUNT following sibling(s) into TARGET list."
+  (unless (node-list-p target)
+    (op-error "Cannot slurp: target is not a list"))
+  (let ((parent (find-parent root target)))
+    (unless parent (op-error "Cannot slurp: target has no parent"))
+    (multiple-value-bind (_bef _found aft) (find-siblings parent target)
+      (declare (ignore _bef _found))
+      (when (null aft)
+        (op-error "Cannot slurp forward: no sibling after target"))
+      (let* ((slurp-nodes (subseq aft 0 (min count (length aft))))
+             (last-slurped (car (last slurp-nodes)))
+             (close-pos (1- (cst-node-end target)))
+             (slurp-end (cst-node-end last-slurped))
+             (slurped (string-trim '(#\Space #\Tab #\Newline #\Return)
+                                   (subseq text (cst-node-end target)
+                                           slurp-end)))
+             (close-char (char text close-pos)))
+        (concatenate 'string
+                     (subseq text 0 close-pos)
+                     " " slurped (string close-char)
+                     (subseq text slurp-end))))))
+
+(defun transform-slurp-backward (text root target &key (count 1))
+  "Pull COUNT preceding sibling(s) into TARGET list."
+  (unless (node-list-p target)
+    (op-error "Cannot slurp: target is not a list"))
+  (let ((parent (find-parent root target)))
+    (unless parent (op-error "Cannot slurp: target has no parent"))
+    (multiple-value-bind (bef _found _aft) (find-siblings parent target)
+      (declare (ignore _found _aft))
+      (when (null bef)
+        (op-error "Cannot slurp backward: no sibling before target"))
+      (let* ((slurp-nodes (last bef (min count (length bef))))
+             (first-slurped (first slurp-nodes))
+             (slurp-start (cst-node-start first-slurped))
+             (open-pos (cst-node-start target))
+             (open-char (char text open-pos))
+             (slurped (string-trim '(#\Space #\Tab #\Newline #\Return)
+                                   (subseq text slurp-start open-pos))))
+        (concatenate 'string
+                     (subseq text 0 slurp-start)
+                     (string open-char) slurped " "
+                     (subseq text (1+ open-pos)))))))
+
+(defun transform-barf-forward (text root target &key (count 1))
+  "Push last COUNT child(ren) out of TARGET as following sibling(s)."
+  (declare (ignore root))
+  (unless (node-list-p target)
+    (op-error "Cannot barf: target is not a list"))
+  (let* ((children (expr-children target))
+         (n (length children)))
+    (when (<= n count)
+      (op-error "Cannot barf ~D children: list only has ~D" count n))
+    (let* ((last-kept (nth (- n count 1) children))
+           (first-barfed (nth (- n count) children))
+           (close-pos (1- (cst-node-end target)))
+           (close-char (char text close-pos))
+           (barfed (string-trim
+                    '(#\Space #\Tab #\Newline #\Return)
+                    (subseq text (cst-node-start first-barfed)
+                            close-pos))))
+      (concatenate 'string
+                   (subseq text 0 (cst-node-end last-kept))
+                   (string close-char) " " barfed
+                   (subseq text (1+ close-pos))))))
+
+(defun transform-barf-backward (text root target &key (count 1))
+  "Push first COUNT child(ren) out of TARGET as preceding sibling(s)."
+  (declare (ignore root))
+  (unless (node-list-p target)
+    (op-error "Cannot barf: target is not a list"))
+  (let* ((children (expr-children target))
+         (n (length children)))
+    (when (<= n count)
+      (op-error "Cannot barf ~D children: list only has ~D" count n))
+    (let* ((first-kept (nth count children))
+           (open-pos (cst-node-start target))
+           (open-char (char text open-pos))
+           (barfed (string-trim
+                    '(#\Space #\Tab #\Newline #\Return)
+                    (subseq text (1+ open-pos)
+                            (cst-node-start first-kept)))))
+      (concatenate 'string
+                   (subseq text 0 open-pos)
+                   barfed " "
+                   (string open-char)
+                   (subseq text (cst-node-start first-kept))))))
+
+(defun transform-kill (text root target &key (count 1))
+  "Delete TARGET and optionally COUNT-1 following siblings."
+  (let ((parent (find-parent root target)))
+    (unless parent (op-error "Cannot kill: target has no parent"))
+    (multiple-value-bind (bef _found aft) (find-siblings parent target)
+      (declare (ignore _found))
+      (let* ((kill-nodes (cons target
+                               (subseq aft 0
+                                       (min (1- count) (length aft)))))
+             (kill-start (cst-node-start (first kill-nodes)))
+             (kill-end (cst-node-end (car (last kill-nodes))))
+             (remaining-aft (nthcdr (min (1- count) (length aft)) aft))
+             (has-before (not (null bef)))
+             (has-after (not (null remaining-aft))))
+        (cond
+          ((and has-before has-after)
+           (let ((clean-start
+                   (loop for i from (1- kill-start) downto 0
+                         for ch = (char text i)
+                         while (member ch '(#\Space #\Tab))
+                         finally (return (1+ i)))))
+             (concatenate 'string
+                          (subseq text 0 clean-start)
+                          (subseq text kill-end))))
+          (has-before
+           (let ((clean-start
+                   (loop for i from (1- kill-start) downto 0
+                         for ch = (char text i)
+                         while (member ch '(#\Space #\Tab
+                                            #\Newline #\Return))
+                         finally (return (1+ i)))))
+             (concatenate 'string
+                          (subseq text 0 clean-start)
+                          (subseq text kill-end))))
+          (t
+           (let* ((len (length text))
+                  (clean-end
+                    (loop for i from kill-end below len
+                          for ch = (char text i)
+                          while (member ch '(#\Space #\Tab
+                                             #\Newline #\Return))
+                          finally (return i))))
+             (concatenate 'string
+                          (subseq text 0 kill-start)
+                          (subseq text clean-end)))))))))
+
+(defun transform-transpose (text root target)
+  "Swap TARGET with its next sibling."
+  (let ((parent (find-parent root target)))
+    (unless parent (op-error "Cannot transpose: target has no parent"))
+    (multiple-value-bind (_bef _found aft) (find-siblings parent target)
+      (declare (ignore _bef _found))
+      (when (null aft)
+        (op-error "Cannot transpose: no next sibling"))
+      (let* ((next (first aft))
+             (a-start (cst-node-start target))
+             (a-end (cst-node-end target))
+             (b-start (cst-node-start next))
+             (b-end (cst-node-end next))
+             (a-text (subseq text a-start a-end))
+             (b-text (subseq text b-start b-end))
+             (between (subseq text a-end b-start)))
+        (concatenate 'string
+                     (subseq text 0 a-start)
+                     b-text between a-text
+                     (subseq text b-end))))))
+
+(defun transform-split (text root target &key clone-head)
+  "Split parent list at TARGET. TARGET becomes first element of second list.
+   CLONE-HEAD: if true, copy operator to both halves."
+  (let ((parent (find-parent root target)))
+    (unless parent (op-error "Cannot split: target has no parent"))
+    (unless (node-list-p parent)
+      (op-error "Cannot split: parent is not a list"))
+    (let* ((p-start (cst-node-start parent))
+           (p-end (cst-node-end parent))
+           (open-char (char text p-start))
+           (close-char (char text (1- p-end))))
+      (multiple-value-bind (before _found after) (find-siblings parent target)
+        (declare (ignore _found))
+        (let* ((left before)
+               (right (cons target after))
+               (children (expr-children parent))
+               (head-text (when (and clone-head left)
+                            (node-source text (first children))))
+               (left-str (format nil "~{~A~^ ~}"
+                                 (mapcar (lambda (n) (node-source text n))
+                                         left)))
+               (right-parts
+                 (if (and clone-head head-text)
+                     (cons head-text
+                           (mapcar (lambda (n) (node-source text n))
+                                   right))
+                     (mapcar (lambda (n) (node-source text n)) right)))
+               (right-str (format nil "~{~A~^ ~}" right-parts)))
+          (concatenate 'string
+                       (subseq text 0 p-start)
+                       (string open-char) left-str (string close-char)
+                       " "
+                       (string open-char) right-str (string close-char)
+                       (subseq text p-end)))))))
+
+(defun transform-join (text root target &key drop-head)
+  "Join TARGET list with its next sibling list.
+   DROP-HEAD: if true, discard the second list's operator."
+  (unless (node-list-p target)
+    (op-error "Cannot join: target is not a list"))
+  (let ((parent (find-parent root target)))
+    (unless parent (op-error "Cannot join: target has no parent"))
+    (multiple-value-bind (_bef _found aft) (find-siblings parent target)
+      (declare (ignore _bef _found))
+      (when (null aft)
+        (op-error "Cannot join: no next sibling"))
+      (let ((next (first aft)))
+        (unless (node-list-p next)
+          (op-error "Cannot join: next sibling is not a list"))
+        (let* ((close-pos (1- (cst-node-end target)))
+               (close-char (char text close-pos))
+               (next-children (expr-children next))
+               (merge (if drop-head (rest next-children) next-children))
+               (merge-text (format nil "~{~A~^ ~}"
+                                   (mapcar (lambda (n) (node-source text n))
+                                           merge))))
+          (concatenate 'string
+                       (subseq text 0 close-pos)
+                       (if merge " " "")
+                       merge-text
+                       (string close-char)
+                       (subseq text (cst-node-end next))))))))
+
+(defun transform-replace (text root target &key new-code)
+  "Replace TARGET node with NEW-CODE."
+  (declare (ignore root))
+  (unless new-code
+    (op-error "Cannot replace: no new-code provided"))
+  (concatenate 'string
+               (subseq text 0 (cst-node-start target))
+               new-code
+               (subseq text (cst-node-end target))))
+
+(defun transform-insert-before (text root target &key new-code)
+  "Insert NEW-CODE as a sibling before TARGET.
+   When TARGET is the same as ROOT (no target specified), prepend to the text."
+  (declare (ignore root))
+  (unless new-code
+    (op-error "Cannot insert: no new-code provided"))
+  (if (zerop (length text))
+      new-code
+      (let ((pos (cst-node-start target)))
+        (if (zerop pos)
+            (concatenate 'string new-code (string #\Newline) (string #\Newline) text)
+            (concatenate 'string
+                         (subseq text 0 pos)
+                         new-code " "
+                         (subseq text pos))))))
+
+(defun transform-insert-after (text root target &key new-code)
+  "Insert NEW-CODE as a sibling after TARGET.
+   When TARGET is the same as ROOT (no target specified), append to the text."
+  (declare (ignore root))
+  (unless new-code
+    (op-error "Cannot insert: no new-code provided"))
+  (if (zerop (length text))
+      new-code
+      (let ((pos (cst-node-end target)))
+        (if (= pos (length text))
+            (concatenate 'string text (string #\Newline) (string #\Newline) new-code)
+            (concatenate 'string
+                         (subseq text 0 pos)
+                         " " new-code
+                         (subseq text pos))))))
+
+
+;;;; Read-only operations
+
+(defun node-kind-string (node)
+  (cond
+    ((eq (cst-node-kind node) :skipped) "comment")
+    ((node-list-p node) "list")
+    ((symbolp (cst-node-value node)) "symbol")
+    ((stringp (cst-node-value node)) "string")
+    ((numberp (cst-node-value node)) "number")
+    (t "atom")))
+
+(defun truncate-text (text max-len)
+  (if (<= (length text) max-len)
+      text
+      (concatenate 'string (subseq text 0 (- max-len 3)) "...")))
+
+(defun show-structure (root text &key (depth 4) (max-text 60))
+  "Build a human-readable tree representation of ROOT's structure."
+  (with-output-to-string (out)
+    (labels ((print-node (node path d indent)
+               (when (and (typep node 'cst-node)
+                          (eq (cst-node-kind node) :expr))
+                 (format out "~A[~{~D~^.~}] ~A L~D: ~A~%"
+                         indent path
+                         (node-kind-string node)
+                         (cst-node-start-line node)
+                         (truncate-text (node-source text node) max-text))
+                 (when (and (node-list-p node) (< d depth))
+                   (loop for child in (expr-children node)
+                         for i from 0
+                         do (print-node child
+                                        (append path (list i))
+                                        (1+ d)
+                                        (concatenate 'string indent "  ")))))))
+      (if (node-list-p root)
+          (loop for child in (expr-children root)
+                for i from 0
+                do (print-node child (list i) 1 ""))
+          (print-node root '() 0 "")))))
+
+(defun get-enclosing (root target text &key (levels 1))
+  "Return info about the enclosing form of TARGET as a formatted string."
+  (let ((current target)
+        (enclosing nil))
+    (dotimes (_ levels)
+      (setf enclosing (find-parent root current))
+      (unless enclosing (return))
+      (setf current enclosing))
+    (unless enclosing
+      (return-from get-enclosing "No enclosing form at requested level"))
+    (let ((children (expr-children enclosing))
+          (child-idx nil))
+      (loop for ch in children for i from 0
+            when (eq ch (if (= levels 1) target current))
+              do (setf child-idx i) (return))
+      (format nil "head: ~A~%kind: ~A~%child_index: ~A~%siblings: ~D~%line: ~D~%text: ~A"
+              (or (node-head-name enclosing) "nil")
+              (node-kind-string enclosing)
+              (or child-idx -1)
+              (length children)
+              (cst-node-start-line enclosing)
+              (truncate-text (node-source text enclosing) 200)))))
+
+
+(defun cst-to-json-ast (nodes text &key (depth 6) (max-text 120))
+  "Convert CST nodes to a JSON string representing the semantic AST.
+   Each node is an object with: type, path, line, start, end, text,
+   and optionally head (for lists) and children."
+  (labels ((node-to-ht (node path d)
+             (when (and (typep node 'cst-node)
+                        (eq (cst-node-kind node) :expr))
+               (let ((ht (make-hash-table :test 'equal)))
+                 (setf (gethash "type" ht) (node-kind-string node)
+                       (gethash "path" ht) (coerce path 'vector)
+                       (gethash "line" ht) (cst-node-start-line node)
+                       (gethash "start" ht) (cst-node-start node)
+                       (gethash "end" ht) (cst-node-end node)
+                       (gethash "text" ht) (truncate-text
+                                            (node-source text node)
+                                            max-text))
+                 (when (node-list-p node)
+                   (let ((head (node-head-name node)))
+                     (when head
+                       (setf (gethash "head" ht) head)))
+                   (when (< d depth)
+                     (let ((ch (loop for child in (expr-children node)
+                                     for i from 0
+                                     for sub = (node-to-ht child
+                                                           (append path (list i))
+                                                           (1+ d))
+                                     when sub collect sub)))
+                       (when ch
+                         (setf (gethash "children" ht)
+                               (coerce ch 'vector))))))
+                 ht))))
+    (let ((top-nodes (loop for node in nodes
+                           for i from 0
+                           for ht = (node-to-ht node (list i) 1)
+                           when ht collect ht)))
+      (with-output-to-string (out)
+        (yason:encode (coerce top-nodes 'vector) out)))))

--- a/src/paredit.lisp
+++ b/src/paredit.lisp
@@ -3,6 +3,8 @@
   (:import-from #:cl-ppcre
                 #:scan-to-strings
                 #:regex-replace-all)
+  (:import-from #:yason
+                #:encode)
   (:import-from #:40ants-lisp-dev-mcp/cst
                 #:cst-node
                 #:make-cst-node
@@ -43,7 +45,7 @@
 (in-package #:40ants-lisp-dev-mcp/paredit)
 
 
-;;;; Error handling
+;;; Error handling
 
 (define-condition paredit-error (simple-error)
   ()
@@ -56,7 +58,7 @@
          :format-arguments args))
 
 
-;;;; Node predicates and accessors
+;;; Node predicates and accessors
 
 (defun node-list-p (node)
   "True if NODE is an :expr CST node whose value is a cons (i.e. a list form)."
@@ -65,6 +67,7 @@
        (consp (cst-node-value node))))
 
 (defun node-atom-p (node)
+  "True if NODE is an :expr CST node whose value is an atom."
   (and (typep node 'cst-node)
        (eq (cst-node-kind node) :expr)
        (atom (cst-node-value node))))
@@ -90,10 +93,11 @@
         (string-downcase (symbol-name (cst-node-value (first children))))))))
 
 (defun normalize-string (thing)
+  "Downcase the printed representation of THING for comparison."
   (string-downcase (princ-to-string thing)))
 
 
-;;;; Top-level form matching
+;;; Top-level form matching
 
 (defun defmethod-candidates (form)
   "Generate candidate name strings for a defmethod form."
@@ -166,9 +170,10 @@
                      (length matches) form-type form-name))))))
 
 
-;;;; Target resolution
+;;; Target resolution
 
 (defun whitespace-normalize (text)
+  "Collapse all runs of whitespace in TEXT to single spaces and trim edges."
   (string-trim '(#\Space #\Tab #\Newline #\Return)
                (regex-replace-all "\\s+" text " ")))
 
@@ -245,7 +250,7 @@
       (t (values root root)))))
 
 
-;;;; Tree navigation
+;;; Tree navigation
 
 (defun find-parent (root target)
   "Find the parent of TARGET within ROOT. NIL if TARGET is ROOT."
@@ -272,8 +277,8 @@
     (values (nreverse before) found (nreverse after))))
 
 
-;;;; Transform functions
-;;;; All transforms are pure: (text root target &key ...) -> new-text
+;;; Transform functions
+;;; All transforms are pure: (text root target &key ...) -> new-text
 
 (defun transform-wrap (text root target &key (count 1) wrapper head)
   "Wrap TARGET (and optionally COUNT-1 following siblings) in new delimiters."
@@ -592,9 +597,10 @@
                          (subseq text pos))))))
 
 
-;;;; Read-only operations
+;;; Read-only operations
 
 (defun node-kind-string (node)
+  "Return a human-readable kind string for NODE."
   (cond
     ((eq (cst-node-kind node) :skipped) "comment")
     ((node-list-p node) "list")
@@ -604,6 +610,7 @@
     (t "atom")))
 
 (defun truncate-text (text max-len)
+  "Truncate TEXT to MAX-LEN characters, appending \"...\" if needed."
   (if (<= (length text) max-len)
       text
       (concatenate 'string (subseq text 0 (- max-len 3)) "...")))

--- a/t/paredit.lisp
+++ b/t/paredit.lisp
@@ -1,0 +1,584 @@
+(uiop:define-package #:40ants-lisp-dev-mcp-tests/paredit
+  (:use #:cl)
+  (:import-from #:rove
+                #:deftest
+                #:ok
+                #:ng
+                #:signals
+                #:testing)
+  (:import-from #:40ants-lisp-dev-mcp/cst
+                #:cst-node
+                #:cst-node-kind
+                #:cst-node-value
+                #:cst-node-children
+                #:cst-node-start
+                #:cst-node-end
+                #:cst-node-start-line
+                #:parse-top-level-forms)
+  (:import-from #:40ants-lisp-dev-mcp/paredit
+                #:resolve-target
+                #:transform-wrap
+                #:transform-unwrap
+                #:transform-raise
+                #:transform-slurp-forward
+                #:transform-slurp-backward
+                #:transform-barf-forward
+                #:transform-barf-backward
+                #:transform-kill
+                #:transform-transpose
+                #:transform-split
+                #:transform-join
+                #:transform-replace
+                #:transform-insert-before
+                #:transform-insert-after
+                #:show-structure
+                #:get-enclosing
+                #:cst-to-json-ast
+                #:paredit-error
+                #:node-source
+                #:node-list-p
+                #:find-parent))
+(in-package #:40ants-lisp-dev-mcp-tests/paredit)
+
+
+;;;; Test helpers
+
+(defun parse-single (text)
+  "Parse TEXT and return the single top-level CST node."
+  (let ((nodes (parse-top-level-forms text)))
+    (assert (= 1 (length nodes)))
+    (first nodes)))
+
+(defun resolve-and-transform (text transform-fn &key target path
+                                                     form-type form-name line
+                                                     &allow-other-keys)
+  "Parse TEXT, resolve target, apply TRANSFORM-FN with remaining keyword args."
+  (let* ((nodes (parse-top-level-forms text))
+         (path-list (when path
+                      (etypecase path
+                        (list path)
+                        (string (mapcar #'parse-integer
+                                        (uiop:split-string path :separator ",")))))))
+    (multiple-value-bind (target-node root-node)
+        (resolve-target nodes text
+                        :form-type form-type :form-name form-name
+                        :target target :path path-list :line line)
+      (values target-node root-node))))
+
+(defun do-transform (text transform-fn target-spec &rest transform-args)
+  "Convenience: parse, resolve by text match, transform.
+   TARGET-SPEC is the source text to match."
+  (let* ((nodes (parse-top-level-forms text)))
+    (multiple-value-bind (target-node root-node)
+        (resolve-target nodes text :target target-spec)
+      (apply transform-fn text root-node target-node transform-args))))
+
+(defun do-transform-path (text transform-fn path &rest transform-args)
+  "Convenience: parse, resolve by path, transform."
+  (let* ((nodes (parse-top-level-forms text)))
+    (multiple-value-bind (target-node root-node)
+        (resolve-target nodes text :path path)
+      (apply transform-fn text root-node target-node transform-args))))
+
+
+;;;; CST parsing tests
+
+(deftest test-parse-simple-atom ()
+  (testing "Parse a single atom"
+    (let ((node (parse-single "hello")))
+      (ok (eq (cst-node-kind node) :expr))
+      (ok (symbolp (cst-node-value node)))
+      (ok (= 0 (cst-node-start node)))
+      (ok (= 5 (cst-node-end node))))))
+
+(deftest test-parse-number ()
+  (testing "Parse a number"
+    (let ((node (parse-single "42")))
+      (ok (eq (cst-node-kind node) :expr))
+      (ok (= 42 (cst-node-value node)))
+      (ok (= 0 (cst-node-start node)))
+      (ok (= 2 (cst-node-end node))))))
+
+(deftest test-parse-simple-list ()
+  (testing "Parse a simple list"
+    (let ((node (parse-single "(a b c)")))
+      (ok (node-list-p node))
+      (ok (= 0 (cst-node-start node)))
+      (ok (= 7 (cst-node-end node)))
+      (ok (= 1 (cst-node-start-line node))))))
+
+(deftest test-parse-nested-list ()
+  (testing "Parse nested lists"
+    (let* ((text "(defun foo (x) (+ x 1))")
+           (node (parse-single text)))
+      (ok (node-list-p node))
+      (ok (string= (node-source text node) text)))))
+
+(deftest test-parse-multiple-forms ()
+  (testing "Parse multiple top-level forms"
+    (let ((nodes (parse-top-level-forms "(a) (b) (c)")))
+      (ok (= 3 (length nodes)))
+      (ok (every #'node-list-p nodes)))))
+
+(deftest test-parse-string-literal ()
+  (testing "Parse string literal"
+    (let* ((text "\"hello world\"")
+           (node (parse-single text)))
+      (ok (stringp (cst-node-value node)))
+      (ok (string= "hello world" (cst-node-value node))))))
+
+(deftest test-parse-preserves-positions ()
+  (testing "Source positions are correct for nested forms"
+    (let* ((text "(+ 1 (* 2 3))")
+           (root (parse-single text))
+           (children (remove-if-not
+                      (lambda (c) (and (typep c 'cst-node)
+                                       (eq (cst-node-kind c) :expr)))
+                      (cst-node-children root))))
+      ;; (+ 1 (* 2 3))
+      ;;  0123456789...
+      (ok (= 3 (length children)))
+      ;; "+"
+      (ok (= 1 (cst-node-start (first children))))
+      (ok (= 2 (cst-node-end (first children))))
+      ;; "1"
+      (ok (= 3 (cst-node-start (second children))))
+      (ok (= 4 (cst-node-end (second children))))
+      ;; "(* 2 3)"
+      (ok (= 5 (cst-node-start (third children))))
+      (ok (= 13 (cst-node-end (third children)))))))
+
+
+;;;; Target resolution tests
+
+(deftest test-resolve-by-text ()
+  (testing "Resolve target by source text"
+    (let* ((text "(a (b c) d)")
+           (nodes (parse-top-level-forms text)))
+      (multiple-value-bind (target root)
+          (resolve-target nodes text :target "(b c)")
+        (declare (ignore root))
+        (ok (string= "(b c)" (node-source text target)))))))
+
+(deftest test-resolve-by-path ()
+  (testing "Resolve target by path"
+    (let* ((text "(a (b c) d)")
+           (nodes (parse-top-level-forms text)))
+      (multiple-value-bind (target root)
+          (resolve-target nodes text :path '(1))
+        (declare (ignore root))
+        (ok (string= "(b c)" (node-source text target)))))))
+
+(deftest test-resolve-by-form-type-name ()
+  (testing "Resolve by form-type and form-name"
+    (let* ((text "(defun foo () 42) (defun bar () 99)")
+           (nodes (parse-top-level-forms text)))
+      (multiple-value-bind (target root)
+          (resolve-target nodes text :form-type "defun" :form-name "bar")
+        (ok (string= "(defun bar () 99)" (node-source text target)))
+        (ok (eq target root))))))
+
+(deftest test-resolve-not-found ()
+  (testing "Error when target not found"
+    (let* ((text "(a b c)")
+           (nodes (parse-top-level-forms text)))
+      (signals paredit-error
+        (resolve-target nodes text :target "zzz")))))
+
+
+;;;; Wrap tests (Emacs paredit: M-( wraps the following sexp)
+
+(deftest test-wrap-single ()
+  (testing "Wrap single expression"
+    ;; (a b c) with target b -> (a (b) c)
+    (ok (string= "(a (b) c)"
+                 (do-transform "(a b c)" #'transform-wrap "b")))))
+
+(deftest test-wrap-multiple ()
+  (testing "Wrap multiple siblings"
+    ;; (a b c d) wrapping b with count 2 -> (a (b c) d)
+    (ok (string= "(a (b c) d)"
+                 (do-transform "(a b c d)" #'transform-wrap "b" :count 2)))))
+
+(deftest test-wrap-with-head ()
+  (testing "Wrap with a head symbol"
+    ;; (a b c) wrapping b with head "progn" -> (a (progn b) c)
+    (ok (string= "(a (progn b) c)"
+                 (do-transform "(a b c)" #'transform-wrap "b"
+                               :head "progn")))))
+
+(deftest test-wrap-square ()
+  (testing "Wrap with square brackets"
+    (ok (string= "(a [b] c)"
+                 (do-transform "(a b c)" #'transform-wrap "b"
+                               :wrapper "square")))))
+
+
+;;;; Unwrap tests (Emacs paredit: M-s splices)
+
+(deftest test-unwrap-all ()
+  (testing "Unwrap keeping all children"
+    ;; (a (b c) d) unwrapping (b c) -> (a b c d)
+    (ok (string= "(a b c d)"
+                 (do-transform "(a (b c) d)" #'transform-unwrap "(b c)")))))
+
+(deftest test-unwrap-body ()
+  (testing "Unwrap keeping body only (drop operator)"
+    ;; (a (progn x y) d) unwrapping with keep=body -> (a x y d)
+    (ok (string= "(a x y d)"
+                 (do-transform "(a (progn x y) d)" #'transform-unwrap
+                               "(progn x y)" :keep "body")))))
+
+(deftest test-unwrap-atom-error ()
+  (testing "Cannot unwrap an atom"
+    (signals paredit-error
+      (do-transform "(a b c)" #'transform-unwrap "b"))))
+
+
+;;;; Raise tests (Emacs paredit: M-r raises)
+
+(deftest test-raise ()
+  (testing "Raise replaces parent with child"
+    ;; (a (b c) d), raise c in (b c) -> (a c d)
+    (ok (string= "(a c d)"
+                 (do-transform "(a (b c) d)" #'transform-raise "c")))))
+
+(deftest test-raise-nested ()
+  (testing "Raise from deeply nested"
+    ;; (+ (* 2 3) 4), raise (* 2 3) -> (* 2 3)
+    (ok (string= "(* 2 3)"
+                 (do-transform "(+ (* 2 3) 4)" #'transform-raise "(* 2 3)")))))
+
+
+;;;; Slurp forward tests (Emacs paredit: C-) slurps forward)
+
+(deftest test-slurp-forward ()
+  (testing "Slurp one sibling forward"
+    ;; (a (b) c d) slurp from (b) -> (a (b c) d)
+    (ok (string= "(a (b c) d)"
+                 (do-transform "(a (b) c d)" #'transform-slurp-forward "(b)")))))
+
+(deftest test-slurp-forward-multiple ()
+  (testing "Slurp two siblings forward"
+    ;; (a (b) c d) slurp 2 from (b) -> (a (b c d))
+    (ok (string= "(a (b c d))"
+                 (do-transform "(a (b) c d)" #'transform-slurp-forward "(b)"
+                               :count 2)))))
+
+(deftest test-slurp-forward-no-sibling ()
+  (testing "Cannot slurp when no sibling after"
+    (signals paredit-error
+      (do-transform "(a (b))" #'transform-slurp-forward "(b)"))))
+
+
+;;;; Slurp backward tests (Emacs paredit: C-( slurps backward)
+
+(deftest test-slurp-backward ()
+  (testing "Slurp one sibling backward"
+    ;; (a b (c) d) slurp backward from (c) -> (a (b c) d)
+    (ok (string= "(a (b c) d)"
+                 (do-transform "(a b (c) d)" #'transform-slurp-backward "(c)")))))
+
+(deftest test-slurp-backward-no-sibling ()
+  (testing "Cannot slurp backward when no preceding sibling"
+    (signals paredit-error
+      (do-transform "((a) b)" #'transform-slurp-backward "(a)"))))
+
+
+;;;; Barf forward tests (Emacs paredit: C-} barfs forward)
+
+(deftest test-barf-forward ()
+  (testing "Barf last child forward"
+    ;; (a (b c d) e) barf from (b c d) -> (a (b c) d e)
+    (ok (string= "(a (b c) d e)"
+                 (do-transform "(a (b c d) e)" #'transform-barf-forward
+                               "(b c d)")))))
+
+(deftest test-barf-forward-too-many ()
+  (testing "Cannot barf more children than available"
+    (signals paredit-error
+      (do-transform "(a (b) c)" #'transform-barf-forward "(b)" :count 1))))
+
+
+;;;; Barf backward tests (Emacs paredit: C-{ barfs backward)
+
+(deftest test-barf-backward ()
+  (testing "Barf first child backward"
+    ;; (a (b c d) e) barf backward from (b c d) -> (a b (c d) e)
+    (ok (string= "(a b (c d) e)"
+                 (do-transform "(a (b c d) e)" #'transform-barf-backward
+                               "(b c d)")))))
+
+
+;;;; Kill tests (Emacs paredit: C-k kills sexp)
+
+(deftest test-kill-middle ()
+  (testing "Kill a middle expression"
+    ;; (a b c) kill b -> (a c)
+    (ok (string= "(a c)"
+                 (do-transform "(a b c)" #'transform-kill "b")))))
+
+(deftest test-kill-last ()
+  (testing "Kill last expression"
+    ;; (a b c) kill c -> (a b)
+    (ok (string= "(a b)"
+                 (do-transform "(a b c)" #'transform-kill "c")))))
+
+(deftest test-kill-first ()
+  (testing "Kill first expression"
+    ;; (a b c) kill a -> (b c)
+    (ok (string= "(b c)"
+                 (do-transform "(a b c)" #'transform-kill "a")))))
+
+(deftest test-kill-multiple ()
+  (testing "Kill multiple consecutive siblings"
+    ;; (a b c d) kill b with count 2 -> (a d)
+    (ok (string= "(a d)"
+                 (do-transform "(a b c d)" #'transform-kill "b" :count 2)))))
+
+
+;;;; Transpose tests (Emacs paredit: C-M-t transposes)
+
+(deftest test-transpose ()
+  (testing "Transpose two siblings"
+    ;; (a b c) transpose a and b -> (b a c)
+    (ok (string= "(b a c)"
+                 (do-transform "(a b c)" #'transform-transpose "a")))))
+
+(deftest test-transpose-lists ()
+  (testing "Transpose list expressions"
+    ;; ((a b) (c d)) transpose -> ((c d) (a b))
+    (ok (string= "((c d) (a b))"
+                 (do-transform "((a b) (c d))" #'transform-transpose "(a b)")))))
+
+(deftest test-transpose-no-next ()
+  (testing "Cannot transpose last sibling"
+    (signals paredit-error
+      (do-transform "(a b c)" #'transform-transpose "c"))))
+
+
+;;;; Split tests (Emacs paredit: M-S splits)
+
+(deftest test-split ()
+  (testing "Split list at target"
+    ;; (a b c d) split at c -> (a b) (c d)
+    (ok (string= "(a b) (c d)"
+                 (do-transform "(a b c d)" #'transform-split "c")))))
+
+(deftest test-split-clone-head ()
+  (testing "Split with clone-head"
+    ;; (progn a b c) split at b with clone -> (progn a) (progn b c)
+    (ok (string= "(progn a) (progn b c)"
+                 (do-transform "(progn a b c)" #'transform-split "b"
+                               :clone-head t)))))
+
+
+;;;; Join tests (Emacs paredit: M-J joins)
+
+(deftest test-join ()
+  (testing "Join two adjacent lists"
+    ;; (a b) (c d) join -> (a b c d)
+    ;; Need to target the first list within a wrapper
+    (let* ((text "((a b) (c d))")
+           (result (do-transform text #'transform-join "(a b)")))
+      (ok (string= "((a b c d))" result)))))
+
+(deftest test-join-drop-head ()
+  (testing "Join with drop-head"
+    (let* ((text "((progn a) (progn b))")
+           (result (do-transform text #'transform-join "(progn a)"
+                                 :drop-head t)))
+      (ok (string= "((progn a b))" result)))))
+
+
+;;;; Replace tests
+
+(deftest test-replace-atom ()
+  (testing "Replace an atom with new code"
+    (ok (string= "(a NEW c)"
+                 (do-transform "(a b c)" #'transform-replace "b"
+                               :new-code "NEW")))))
+
+(deftest test-replace-list ()
+  (testing "Replace a list with new code"
+    (ok (string= "(a (x y z) d)"
+                 (do-transform "(a (b c) d)" #'transform-replace "(b c)"
+                               :new-code "(x y z)")))))
+
+(deftest test-replace-with-multiline ()
+  (testing "Replace with multiline code"
+    (let ((result (do-transform "(defun foo () nil)" #'transform-replace "nil"
+                                :new-code "(let ((x 1))
+  (+ x 2))")))
+      (ok (search "(let ((x 1))" result)))))
+
+
+;;;; Insert tests
+
+(deftest test-insert-before ()
+  (testing "Insert before a sibling"
+    (ok (string= "(NEW a b c)"
+                 (do-transform "(a b c)" #'transform-insert-before "a"
+                               :new-code "NEW")))))
+
+(deftest test-insert-after ()
+  (testing "Insert after a sibling"
+    (ok (string= "(a b c NEW)"
+                 (do-transform "(a b c)" #'transform-insert-after "c"
+                               :new-code "NEW")))))
+
+(deftest test-insert-after-top-level ()
+  (testing "Insert after at top level (append)"
+    (let* ((text "(defun foo () 1)")
+           (nodes (parse-top-level-forms text)))
+      (multiple-value-bind (target root)
+          (resolve-target nodes text)
+        (let ((result (transform-insert-after text root target
+                                              :new-code "(defun bar () 2)")))
+          (ok (search "(defun foo () 1)" result))
+          (ok (search "(defun bar () 2)" result)))))))
+
+(deftest test-insert-empty-code ()
+  (testing "Insert into empty code (build from scratch)"
+    (let* ((root (40ants-lisp-dev-mcp/cst:make-cst-node
+                  :kind :expr :value nil :start 0 :end 0))
+           (result (transform-insert-after "" root root
+                                           :new-code "(defun foo () 42)")))
+      (ok (string= "(defun foo () 42)" result)))))
+
+
+;;;; Show-structure tests
+
+(deftest test-show-structure ()
+  (testing "Show structure returns tree text"
+    (let* ((text "(defun foo (x) (+ x 1))")
+           (root (parse-single text))
+           (result (show-structure root text)))
+      (ok (search "list" result))
+      (ok (search "defun" result)))))
+
+
+;;;; Get-enclosing tests
+
+(deftest test-get-enclosing ()
+  (testing "Get enclosing form info"
+    (let* ((text "(defun foo (x) (+ x 1))")
+           (nodes (parse-top-level-forms text)))
+      (multiple-value-bind (target root)
+          (resolve-target nodes text :target "(+ x 1)")
+        (let ((result (get-enclosing root target text)))
+          (ok (search "defun" result))
+          (ok (search "list" result)))))))
+
+
+;;;; Round-trip tests
+
+(deftest test-roundtrip-wrap-unwrap ()
+  (testing "Wrap then unwrap is identity"
+    (let* ((text "(a b c)")
+           (wrapped (do-transform text #'transform-wrap "b"))
+           (nodes2 (parse-top-level-forms wrapped)))
+      (multiple-value-bind (target2 root2)
+          (resolve-target nodes2 wrapped :target "(b)")
+        (let ((unwrapped (transform-unwrap wrapped root2 target2)))
+          (ok (string= text unwrapped)))))))
+
+(deftest test-roundtrip-slurp-barf ()
+  (testing "Slurp forward then barf forward is identity"
+    (let* ((text "(a (b) c)")
+           (slurped (do-transform text #'transform-slurp-forward "(b)"))
+           (nodes2 (parse-top-level-forms slurped)))
+      (multiple-value-bind (target2 root2)
+          (resolve-target nodes2 slurped :target "(b c)")
+        (let ((barfed (transform-barf-forward slurped root2 target2)))
+          (ok (string= text barfed)))))))
+
+(deftest test-roundtrip-transpose-twice ()
+  (testing "Transpose twice returns to original"
+    (let* ((text "(a b c)")
+           ;; transpose a and b -> (b a c)
+           (pass1 (do-transform text #'transform-transpose "a"))
+           ;; transpose a and c -> (b c a)... no, need to transpose b with a again
+           ;; Actually need to target "a" (now second) in (b a c)
+           (nodes2 (parse-top-level-forms pass1)))
+      ;; In (b a c), find "a" which is now second child, transpose with c
+      ;; To get back to (a b c), we need to target "b" in (b a c)
+      (multiple-value-bind (target2 root2)
+          (resolve-target nodes2 pass1 :path '(0))
+        (let ((pass2 (transform-transpose pass1 root2 target2)))
+          ;; (b a c) -> transpose b with a -> (a b c)
+          (ok (string= text pass2)))))))
+
+
+;;;; Emacs paredit-inspired scenarios
+
+(deftest test-paredit-scenario-wrap-function-call ()
+  (testing "Wrap a value in a function call: x -> (1+ x)"
+    (let ((result (do-transform "(setf x 5)" #'transform-wrap "5"
+                                :head "1+")))
+      (ok (string= "(setf x (1+ 5))" result)))))
+
+(deftest test-paredit-scenario-extract-to-let ()
+  (testing "Complex scenario: wrap expression for let binding"
+    (let* ((text "(defun foo () (+ 1 2))")
+           ;; Wrap (+ 1 2) with let
+           (result (do-transform text #'transform-wrap "(+ 1 2)"
+                                 :head "let ((x 42))")))
+      (ok (search "let ((x 42))" result))
+      (ok (search "(+ 1 2)" result)))))
+
+(deftest test-paredit-scenario-build-file ()
+  (testing "Build a file from scratch using insert"
+    (let* ((code "")
+           ;; Step 1: create the package definition
+           (root1 (40ants-lisp-dev-mcp/cst:make-cst-node
+                   :kind :expr :value nil :start 0 :end 0))
+           (code (transform-insert-after code root1 root1
+                                         :new-code "(defpackage :my-pkg (:use :cl))"))
+           ;; Step 2: add in-package
+           (nodes2 (parse-top-level-forms code)))
+      (multiple-value-bind (target2 root2)
+          (resolve-target nodes2 code)
+        (let ((code (transform-insert-after code root2 target2
+                                            :new-code "(in-package :my-pkg)")))
+          ;; Step 3: add a function
+          (let ((nodes3 (parse-top-level-forms code)))
+            (multiple-value-bind (target3 root3)
+                (resolve-target nodes3 code :target "(in-package :my-pkg)")
+              (let ((final (transform-insert-after code root3 target3
+                                                   :new-code "(defun hello () (format t \"Hello!\"))")))
+                (ok (search "defpackage" final))
+                (ok (search "in-package" final))
+                (ok (search "defun hello" final))))))))))
+
+
+;;;; JSON AST tests
+
+(deftest test-json-ast-basic ()
+  (testing "JSON AST contains expected fields"
+    (let* ((text "(defun foo (x) (+ x 1))")
+           (nodes (parse-top-level-forms text))
+           (json (cst-to-json-ast nodes text)))
+      (ok (search "\"type\"" json))
+      (ok (search "\"list\"" json))
+      (ok (search "\"head\"" json))
+      (ok (search "\"defun\"" json))
+      (ok (search "\"path\"" json))
+      (ok (search "\"children\"" json)))))
+
+(deftest test-json-ast-multiple-forms ()
+  (testing "JSON AST handles multiple top-level forms"
+    (let* ((text "(defun foo () 1) (defvar *x* 42)")
+           (nodes (parse-top-level-forms text))
+           (json (cst-to-json-ast nodes text)))
+      (ok (search "defun" json))
+      (ok (search "defvar" json)))))
+
+(deftest test-json-ast-atom ()
+  (testing "JSON AST represents atoms"
+    (let* ((text "(+ 1 \"hello\")")
+           (nodes (parse-top-level-forms text))
+           (json (cst-to-json-ast nodes text)))
+      (ok (search "\"number\"" json))
+      (ok (search "\"string\"" json))
+      (ok (search "\"symbol\"" json)))))

--- a/t/paredit.lisp
+++ b/t/paredit.lisp
@@ -4,7 +4,6 @@
                 #:deftest
                 #:ok
                 #:ng
-                #:signals
                 #:testing)
   (:import-from #:40ants-lisp-dev-mcp/cst
                 #:cst-node
@@ -41,7 +40,12 @@
 (in-package #:40ants-lisp-dev-mcp-tests/paredit)
 
 
-;;;; Test helpers
+;;; Test helpers
+
+(defmacro signals-paredit-error (&body body)
+  "Assert that BODY signals a paredit-error condition."
+  `(ok (handler-case (progn ,@body nil)
+         (paredit-error () t))))
 
 (defun parse-single (text)
   "Parse TEXT and return the single top-level CST node."
@@ -53,6 +57,7 @@
                                                      form-type form-name line
                                                      &allow-other-keys)
   "Parse TEXT, resolve target, apply TRANSFORM-FN with remaining keyword args."
+  (declare (ignore transform-fn))
   (let* ((nodes (parse-top-level-forms text))
          (path-list (when path
                       (etypecase path
@@ -81,7 +86,7 @@
       (apply transform-fn text root-node target-node transform-args))))
 
 
-;;;; CST parsing tests
+;;; CST parsing tests
 
 (deftest test-parse-simple-atom ()
   (testing "Parse a single atom"
@@ -144,12 +149,12 @@
       ;; "1"
       (ok (= 3 (cst-node-start (second children))))
       (ok (= 4 (cst-node-end (second children))))
-      ;; "(* 2 3)"
+      ;; "(* 2 3)" starts at 5, ends at 12
       (ok (= 5 (cst-node-start (third children))))
-      (ok (= 13 (cst-node-end (third children)))))))
+      (ok (= 12 (cst-node-end (third children)))))))
 
 
-;;;; Target resolution tests
+;;; Target resolution tests
 
 (deftest test-resolve-by-text ()
   (testing "Resolve target by source text"
@@ -182,11 +187,11 @@
   (testing "Error when target not found"
     (let* ((text "(a b c)")
            (nodes (parse-top-level-forms text)))
-      (signals paredit-error
-        (resolve-target nodes text :target "zzz")))))
+    (signals-paredit-error
+      (resolve-target nodes text :target "zzz")))))
 
 
-;;;; Wrap tests (Emacs paredit: M-( wraps the following sexp)
+;;; Wrap tests (Emacs paredit: M-( wraps the following sexp)
 
 (deftest test-wrap-single ()
   (testing "Wrap single expression"
@@ -214,7 +219,7 @@
                                :wrapper "square")))))
 
 
-;;;; Unwrap tests (Emacs paredit: M-s splices)
+;;; Unwrap tests (Emacs paredit: M-s splices)
 
 (deftest test-unwrap-all ()
   (testing "Unwrap keeping all children"
@@ -231,11 +236,11 @@
 
 (deftest test-unwrap-atom-error ()
   (testing "Cannot unwrap an atom"
-    (signals paredit-error
+    (signals-paredit-error
       (do-transform "(a b c)" #'transform-unwrap "b"))))
 
 
-;;;; Raise tests (Emacs paredit: M-r raises)
+;;; Raise tests (Emacs paredit: M-r raises)
 
 (deftest test-raise ()
   (testing "Raise replaces parent with child"
@@ -250,7 +255,7 @@
                  (do-transform "(+ (* 2 3) 4)" #'transform-raise "(* 2 3)")))))
 
 
-;;;; Slurp forward tests (Emacs paredit: C-) slurps forward)
+;;; Slurp forward tests (Emacs paredit: C-) slurps forward)
 
 (deftest test-slurp-forward ()
   (testing "Slurp one sibling forward"
@@ -267,11 +272,11 @@
 
 (deftest test-slurp-forward-no-sibling ()
   (testing "Cannot slurp when no sibling after"
-    (signals paredit-error
+    (signals-paredit-error
       (do-transform "(a (b))" #'transform-slurp-forward "(b)"))))
 
 
-;;;; Slurp backward tests (Emacs paredit: C-( slurps backward)
+;;; Slurp backward tests (Emacs paredit: C-( slurps backward)
 
 (deftest test-slurp-backward ()
   (testing "Slurp one sibling backward"
@@ -281,11 +286,11 @@
 
 (deftest test-slurp-backward-no-sibling ()
   (testing "Cannot slurp backward when no preceding sibling"
-    (signals paredit-error
+    (signals-paredit-error
       (do-transform "((a) b)" #'transform-slurp-backward "(a)"))))
 
 
-;;;; Barf forward tests (Emacs paredit: C-} barfs forward)
+;;; Barf forward tests (Emacs paredit: C-} barfs forward)
 
 (deftest test-barf-forward ()
   (testing "Barf last child forward"
@@ -296,11 +301,11 @@
 
 (deftest test-barf-forward-too-many ()
   (testing "Cannot barf more children than available"
-    (signals paredit-error
+    (signals-paredit-error
       (do-transform "(a (b) c)" #'transform-barf-forward "(b)" :count 1))))
 
 
-;;;; Barf backward tests (Emacs paredit: C-{ barfs backward)
+;;; Barf backward tests (Emacs paredit: C-{ barfs backward)
 
 (deftest test-barf-backward ()
   (testing "Barf first child backward"
@@ -310,7 +315,7 @@
                                "(b c d)")))))
 
 
-;;;; Kill tests (Emacs paredit: C-k kills sexp)
+;;; Kill tests (Emacs paredit: C-k kills sexp)
 
 (deftest test-kill-middle ()
   (testing "Kill a middle expression"
@@ -337,7 +342,7 @@
                  (do-transform "(a b c d)" #'transform-kill "b" :count 2)))))
 
 
-;;;; Transpose tests (Emacs paredit: C-M-t transposes)
+;;; Transpose tests (Emacs paredit: C-M-t transposes)
 
 (deftest test-transpose ()
   (testing "Transpose two siblings"
@@ -353,11 +358,11 @@
 
 (deftest test-transpose-no-next ()
   (testing "Cannot transpose last sibling"
-    (signals paredit-error
+    (signals-paredit-error
       (do-transform "(a b c)" #'transform-transpose "c"))))
 
 
-;;;; Split tests (Emacs paredit: M-S splits)
+;;; Split tests (Emacs paredit: M-S splits)
 
 (deftest test-split ()
   (testing "Split list at target"
@@ -373,7 +378,7 @@
                                :clone-head t)))))
 
 
-;;;; Join tests (Emacs paredit: M-J joins)
+;;; Join tests (Emacs paredit: M-J joins)
 
 (deftest test-join ()
   (testing "Join two adjacent lists"
@@ -391,7 +396,7 @@
       (ok (string= "((progn a b))" result)))))
 
 
-;;;; Replace tests
+;;; Replace tests
 
 (deftest test-replace-atom ()
   (testing "Replace an atom with new code"
@@ -413,7 +418,7 @@
       (ok (search "(let ((x 1))" result)))))
 
 
-;;;; Insert tests
+;;; Insert tests
 
 (deftest test-insert-before ()
   (testing "Insert before a sibling"
@@ -447,7 +452,7 @@
       (ok (string= "(defun foo () 42)" result)))))
 
 
-;;;; Show-structure tests
+;;; Show-structure tests
 
 (deftest test-show-structure ()
   (testing "Show structure returns tree text"
@@ -458,7 +463,7 @@
       (ok (search "defun" result)))))
 
 
-;;;; Get-enclosing tests
+;;; Get-enclosing tests
 
 (deftest test-get-enclosing ()
   (testing "Get enclosing form info"
@@ -471,7 +476,7 @@
           (ok (search "list" result)))))))
 
 
-;;;; Round-trip tests
+;;; Round-trip tests
 
 (deftest test-roundtrip-wrap-unwrap ()
   (testing "Wrap then unwrap is identity"
@@ -510,7 +515,7 @@
           (ok (string= text pass2)))))))
 
 
-;;;; Emacs paredit-inspired scenarios
+;;; Emacs paredit-inspired scenarios
 
 (deftest test-paredit-scenario-wrap-function-call ()
   (testing "Wrap a value in a function call: x -> (1+ x)"
@@ -552,7 +557,7 @@
                 (ok (search "defun hello" final))))))))))
 
 
-;;;; JSON AST tests
+;;; JSON AST tests
 
 (deftest test-json-ast-basic ()
   (testing "JSON AST contains expected fields"


### PR DESCRIPTION
Mostly vibe coded (Opus 4.6) set of paredit-like sexp manipulation tools.

- Added paredit-style structural editing tools (wrap, unwrap, raise, slurp, barf, kill, transpose, split, join).
- Added sexp-replace, sexp-insert-before, sexp-insert-after for code replacement and insertion.
- Added sexp-show-structure and sexp-get-enclosing for code inspection.
- Added sexp-to-json-ast for CST-based JSON AST output.
- Added Eclector-based CST parser with source position tracking.
- Added devcontainer configuration